### PR TITLE
Getting a 404 on wordpress.png

### DIFF
--- a/css/twentyten-style.css
+++ b/css/twentyten-style.css
@@ -1199,7 +1199,7 @@ h3#reply-title {
 	position: relative;
 }
 #site-generator a {
-	background: url(images/wordpress.png) center left no-repeat;
+	background: url(../images/wordpress.png) center left no-repeat;
 	color: #666;
 	display: inline-block;
 	line-height: 16px;


### PR DESCRIPTION
The image reference in the css has to be a relative (../image) url rather than an explicit (image/...) one
